### PR TITLE
Rabbit fails to load if persistent store is enabled

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,41 @@
+name: Build and Publish Rabbit Image
+
+on:
+  workflow_dispatch:
+    inputs:
+      image_tag:
+        description: 'Image tag'
+        required: true
+        default: 'mq3.12.10-el22.3-ltsc2019'
+
+jobs:
+  build-and-publish-image:
+    runs-on: windows-2019
+    env:
+      MAIN_IMAGE_NAME: ${{ secrets.CONTAINER_REGISTRY_NAME }}/rabbit-mq:${{ github.sha }}
+      LATEST_IMAGE_NAME: ${{ secrets.CONTAINER_REGISTRY_NAME }}/rabbit-mq:latest
+      VERSION_IMAGE_NAME: ${{ secrets.CONTAINER_REGISTRY_NAME }}/rabbit-mq:${{ github.event.inputs.image_tag }}
+
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Docker Hub login
+      uses: azure/docker-login@v1
+      with:
+        username: ${{ secrets.DOCKERHUB_USERNAME }}
+        password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+    - name: Build Rabbit Image
+      shell: pwsh
+      run: |
+        cd rabbit-mq
+        docker build . -t $env:MAIN_IMAGE_NAME
+        docker tag $env:MAIN_IMAGE_NAME $env:LATEST_IMAGE_NAME
+        docker tag $env:MAIN_IMAGE_NAME $env:VERSION_IMAGE_NAME
+
+    - name: Push Rabbit Image to Docker Hub
+      shell: pwsh
+      run: |
+        docker push $env:MAIN_IMAGE_NAME
+        docker push $env:LATEST_IMAGE_NAME
+        docker push $env:VERSION_IMAGE_NAME

--- a/rabbit-mq/Dockerfile
+++ b/rabbit-mq/Dockerfile
@@ -1,13 +1,14 @@
 ARG OS_VERSION=ltsc2019
 FROM mcr.microsoft.com/windows/servercore:$OS_VERSION
 
-ARG RABBIT_VERSION=3.8.11
+ARG RABBIT_VERSION=3.12.10
 ENV RABBIT_VERSION=$RABBIT_VERSION
-ARG ERLANG_VERSION=22.3
+ARG ERLANG_VERSION=26.2.1
 ENV ERLANG_VERSION=$ERLANG_VERSION
 
+ENV chocolateyVersion=1.4.0
 ENV chocolateyUseWindowsCompression false
-ENV ERLANG_SERVICE_MANAGER_PATH="C:\Program Files\erl8.3\erts-8.3\bin"
+ENV ERLANG_SERVICE_MANAGER_PATH="C:\Program Files\Erlang OTP\erts-14.2.1\bin"
 ENV RABBITMQ_SERVER="C:\Program Files\RabbitMQ Server\rabbitmq_server-${RABBIT_VERSION}"
 ENV ADMIN_PASSWORD=password1234@1
 ENV BASE_PASSWORD=password1234@1
@@ -21,6 +22,7 @@ RUN choco install -y rabbitmq --version $env:RABBIT_VERSION
 
 COPY provisioning/ C:/
 COPY provisioning/ C:/Users/ContainerAdministrator/AppData/Roaming/RabbitMQ/
+RUN mkdir C:/RabbitMessageStore
 
 EXPOSE 4369
 EXPOSE 5672
@@ -28,6 +30,8 @@ EXPOSE 5671
 EXPOSE 15672
 
 WORKDIR C:/Program\ Files/RabbitMQ\ Server/rabbitmq_server-${RABBIT_VERSION}/sbin
+RUN ./rabbitmq-service.bat stop
+RUN ./rabbitmq-service.bat remove
 COPY ./startUp.ps1 ./
 COPY ./firstStart.ps1 ./firstStart.ps1
 CMD ["powershell", "-Command", "./startUp.ps1"]


### PR DESCRIPTION
- Upgraded the Rabbit version to 3.12.10
- Upgraded the Erlang version to 26.2.1
- Updated ERLANG_SERVICE_MANAGER_PATH for new version of Erlang
- Force chocolatey version to 1.4.0 to get around a [build failure issue](https://stackoverflow.com/questions/76470752/chocolatey-installation-in-docker-started-to-fail-restart-due-to-net-framework)
- Stop the autostart of the rabbit MQ service after being installed by Chocolatey
- Added a new Github Action workflow to manually build and deploy rabbit-mq to Docker Hub requires the following secrets (CONTAINER_REGISTRY_NAME, DOCKERHUB_USERNAME, DOCKERHUB_TOKEN)